### PR TITLE
feat: 로그인 여부로 헤더 및 컴포넌트 변경

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -24,6 +24,7 @@ const Header = () => {
         </LogoText>
       </MainLogo>
 
+      {/* 데스크탑 menu */}
       <MenuList
         style={{ color: path.includes(MY_PAGE.ROOT) ? '#fff' : '#000' }}>
         {path !== STREET.ROOT && (
@@ -32,8 +33,14 @@ const Header = () => {
           </Menu>
         )}
         <Menu onClick={() => navigate(POSTING)}>전단지 붙이기</Menu>
-        <Menu>로그인 / 회원가입</Menu>
+        {!isLogin ? (
+          <Menu>로그인 / 회원가입</Menu>
+        ) : (
+          <Menu onClick={() => navigate(ROUTES.MY_PAGE.ROOT)}>마이페이지</Menu>
+        )}
       </MenuList>
+
+      {/* 모바일 menu */}
       <MenuList id='mobile'>
         {path === HOME && (
           <NavIcon
@@ -60,7 +67,13 @@ const Header = () => {
           />
         )}
 
-        {isLogin && <NavIcon src='/img/profile.svg' alt='profile' />}
+        {isLogin && (
+          <NavIcon
+            onClick={() => navigate(ROUTES.MY_PAGE.ROOT)}
+            src='/img/profile.svg'
+            alt='profile'
+          />
+        )}
       </MenuList>
     </Container>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,14 +1,12 @@
 import styled from '@emotion/styled';
 import { useLocation, useNavigate } from 'react-router-dom';
 
-import { TOKEN_KEY } from '../constants/auth';
 import { COLORS } from '../constants/colors';
 import { ROUTES } from '../constants/routes';
-import { getLocalStorage } from '../utils/storage';
+import { isLogin } from '../utils/storage';
 
 const Header = () => {
   const navigate = useNavigate();
-  const isLogin = getLocalStorage(TOKEN_KEY);
   const { pathname: path } = useLocation();
   const { HOME, STREET, POSTING, MY_PAGE } = ROUTES;
   const background = path.includes(MY_PAGE.ROOT) ? COLORS.MAIN : 'none';
@@ -33,7 +31,7 @@ const Header = () => {
           </Menu>
         )}
         <Menu onClick={() => navigate(POSTING)}>전단지 붙이기</Menu>
-        {!isLogin ? (
+        {!isLogin() ? (
           <Menu>로그인 / 회원가입</Menu>
         ) : (
           <Menu onClick={() => navigate(ROUTES.MY_PAGE.ROOT)}>마이페이지</Menu>
@@ -67,7 +65,7 @@ const Header = () => {
           />
         )}
 
-        {isLogin && (
+        {isLogin() && (
           <NavIcon
             onClick={() => navigate(ROUTES.MY_PAGE.ROOT)}
             src='/img/profile.svg'

--- a/src/components/Home/MainSection.tsx
+++ b/src/components/Home/MainSection.tsx
@@ -1,12 +1,11 @@
 import styled from '@emotion/styled';
 import { useNavigate } from 'react-router-dom';
 
-import { TOKEN_KEY } from '../../constants/auth';
 import { COLORS } from '../../constants/colors';
 import { ROUTES } from '../../constants/routes';
 import useCountNumber from '../../hooks/useCountNumber';
 import useGetCount from '../../hooks/useGetCount';
-import { getLocalStorage } from '../../utils/storage';
+import { isLogin } from '../../utils/storage';
 import Flyer from '../shared/Flyer';
 import OAuthButton from '../shared/OAuthButton';
 
@@ -14,7 +13,6 @@ const MainSection = () => {
   const navigate = useNavigate();
   const number = useGetCount();
   const count = useCountNumber(number);
-  const isLogin = getLocalStorage(TOKEN_KEY);
   const goStreet = () => navigate(ROUTES.STREET.DETAIL('total', '', 'new', ''));
 
   return (
@@ -60,7 +58,7 @@ const MainSection = () => {
           <TitleMob id='count'>{count}</TitleMob>개
         </TitleMob>
 
-        {!isLogin ? (
+        {!isLogin() ? (
           <LoginMob>
             <OAuthButton type='naver' />
             <OAuthButton type='kakao' />

--- a/src/components/Home/MainSection.tsx
+++ b/src/components/Home/MainSection.tsx
@@ -1,10 +1,12 @@
 import styled from '@emotion/styled';
 import { useNavigate } from 'react-router-dom';
 
+import { TOKEN_KEY } from '../../constants/auth';
 import { COLORS } from '../../constants/colors';
 import { ROUTES } from '../../constants/routes';
 import useCountNumber from '../../hooks/useCountNumber';
 import useGetCount from '../../hooks/useGetCount';
+import { getLocalStorage } from '../../utils/storage';
 import Flyer from '../shared/Flyer';
 import OAuthButton from '../shared/OAuthButton';
 
@@ -12,7 +14,7 @@ const MainSection = () => {
   const navigate = useNavigate();
   const number = useGetCount();
   const count = useCountNumber(number);
-
+  const isLogin = getLocalStorage(TOKEN_KEY);
   const goStreet = () => navigate(ROUTES.STREET.DETAIL('total', '', 'new', ''));
 
   return (
@@ -58,16 +60,14 @@ const MainSection = () => {
           <TitleMob id='count'>{count}</TitleMob>개
         </TitleMob>
 
-        {/* 비로그인 - 로그인 버튼 */}
-        <LoginMob>
-          <OAuthButton type='naver' />
-          <OAuthButton type='kakao' />
-        </LoginMob>
-
-        {/* 로그인 - 전단지 골목 가기 버튼 */}
-        <div>
+        {!isLogin ? (
+          <LoginMob>
+            <OAuthButton type='naver' />
+            <OAuthButton type='kakao' />
+          </LoginMob>
+        ) : (
           <Button onClick={goStreet}>전단지 골목 가기</Button>
-        </div>
+        )}
       </ContainerMob>
     </Section>
   );
@@ -154,7 +154,6 @@ const Button = styled.button`
   @media all and (max-width: 767px) {
     font-weight: 500;
     margin-top: 30px;
-    display: none;
   }
 `;
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -2,15 +2,13 @@ import LoginSection from '../components/Home/LoginSection';
 import MainSection from '../components/Home/MainSection';
 import MovingText from '../components/Home/MovingText';
 import PromotionSection from '../components/Home/PromotionSection';
-import { TOKEN_KEY } from '../constants/auth';
-import { getLocalStorage } from '../utils/storage';
+import { isLogin } from '../utils/storage';
 
 const Home = () => {
-  const isLogin = getLocalStorage(TOKEN_KEY);
   return (
     <div style={{ overflow: 'hidden' }}>
       <MainSection />
-      {!isLogin ? (
+      {!isLogin() ? (
         <>
           <PromotionSection />
           <MovingText />

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -2,14 +2,21 @@ import LoginSection from '../components/Home/LoginSection';
 import MainSection from '../components/Home/MainSection';
 import MovingText from '../components/Home/MovingText';
 import PromotionSection from '../components/Home/PromotionSection';
+import { TOKEN_KEY } from '../constants/auth';
+import { getLocalStorage } from '../utils/storage';
 
 const Home = () => {
+  const isLogin = getLocalStorage(TOKEN_KEY);
   return (
     <div style={{ overflow: 'hidden' }}>
       <MainSection />
-      <PromotionSection />
-      <MovingText />
-      <LoginSection />
+      {!isLogin ? (
+        <>
+          <PromotionSection />
+          <MovingText />
+          <LoginSection />
+        </>
+      ) : null}
     </div>
   );
 };


### PR DESCRIPTION
로그인 시
1. 헤더 - 로그인/회원가입=>마이페이지로 변경
2. 메인 섹션만 남고 나머지 섹션 없어짐
3. 모바일 - 로그인버튼 사라지고 전단지 골목 가기 버튼으로 변경됨